### PR TITLE
Enable usage with webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,6 @@
     },
     "spm": {
         "main": "lib/gettext.js"
-    }
+    },
+    "main": "lib/gettext.js"
 }


### PR DESCRIPTION
Webpack cannot resolve the main file as it was missing from package.json. Please add the proposed "main" entry to allow it to be recognized by webpack.