### PR TITLE
Fix for node / not browser context

### DIFF
--- a/lib/gettext.js
+++ b/lib/gettext.js
@@ -7,7 +7,7 @@
     // default values that could be overriden in i18n() construct
     var defaults = {
       domain: 'messages',
-      locale: document.documentElement.getAttribute('lang') || 'en',
+      locale: window && document.documentElement.getAttribute('lang') || 'en',
       plural_func: function (n) { return { nplurals: 2, plural: (n!=1) ? 1 : 0 }; },
       ctxt_delimiter: String.fromCharCode(4) // \u0004
     };


### PR DESCRIPTION
document is undefined when not executed in browsers