### PR TITLE
Add support for language with subtags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # gettext.js changelog
 
+    - add support for language with subtags
+
 **[0.5.2]**
 
     - fixed bugs for plurals. (#2)

--- a/lib/gettext.js
+++ b/lib/gettext.js
@@ -51,6 +51,17 @@
         });
       };
 
+      var expand_locale = function(locale) {
+          var locales = [locale],
+              i = locale.lastIndexOf('-');
+          while (i > 0) {
+              locale = locale.slice(0, i);
+              locales.push(locale);
+              i = locale.lastIndexOf('-');
+          }
+          return locales;
+      };
+
       var getPluralFunc = function (plural_form) {
         // Plural form string regexp
         // taken from https://github.com/Orange-OpenSource/gettext.js/blob/master/lib.gettext.js
@@ -99,6 +110,7 @@
 
     return {
       strfmt: strfmt, // expose strfmt util
+      expand_locale: expand_locale, // expose expand_locale util
 
       // Declare shortcuts
       __: function () { return this.gettext.apply(this, arguments); },
@@ -167,22 +179,31 @@
           translation,
           options = {},
           key = msgctxt ? msgctxt + _ctxt_delimiter + msgid : msgid,
-          exist = _dictionary[domain] && _dictionary[domain][_locale] && _dictionary[domain][_locale][key];
+          exist,
+          locale;
+        var locales = expand_locale(_locale);
+        for (var i in locales) {
+            locale = locales[i];
+            exist = _dictionary[domain] && _dictionary[domain][locale] && _dictionary[domain][locale][key];
 
-        // because it's not possible to define both a singular and a plural form of the same msgid,
-        // we need to check that the stored form is the same as the expected one.
-        // if not, we'll just ignore the translation and consider it as not translated.
-        if (msgid_plural) {
-          exist = exist && "string" !== typeof _dictionary[domain][_locale][key];
-        } else {
-          exist = exist && "string" === typeof _dictionary[domain][_locale][key];
+            // because it's not possible to define both a singular and a plural form of the same msgid,
+            // we need to check that the stored form is the same as the expected one.
+            // if not, we'll just ignore the translation and consider it as not translated.
+            if (msgid_plural) {
+              exist = exist && "string" !== typeof _dictionary[domain][locale][key];
+            } else {
+              exist = exist && "string" === typeof _dictionary[domain][locale][key];
+            }
+            if (exist) {
+                break;
+            }
         }
 
         if (!exist) {
           translation = msgid;
           options.plural_func = defaults.plural_func;
         } else {
-          translation = _dictionary[domain][_locale][key];
+          translation = _dictionary[domain][locale][key];
         }
 
         // Singular form

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -52,6 +52,18 @@
                 });
             });
 
+            describe('expand_locale', function() {
+                it('should be a i18n method', function() {
+                    expect(i18n.expand_locale).to.be.a('function');
+                });
+                it('should handle simple locale', function() {
+                    expect(i18n.expand_locale('fr')).to.eql(['fr']);
+                });
+                it('should handle complex locale', function() {
+                    expect(i18n.expand_locale('de-CH-1996')).to.eql(['de-CH-1996', 'de-CH', 'de']);
+                });
+            });
+
             describe('gettext', function () {
                 it('should handle peacefully singular untranslated keys', function () {
                     expect(i18n.gettext('not translated')).to.be('not translated');
@@ -59,6 +71,24 @@
                 it('should handle peacefully singular untranslated keys with extra', function () {
                     expect(i18n.gettext('not %1 translated', 'correctly')).to.be('not correctly translated');
                     expect(i18n.gettext('not %1 %2 translated', 'fully', 'correctly')).to.be('not fully correctly translated');
+                });
+                it('should fallback to father language', function() {
+                    i18n = new window.i18n();
+                    i18n.setMessages('messages', 'fr', {
+                        "Mop": "Serpillière",
+                    });
+                    i18n.setMessages('messages', 'fr-BE', {
+                        "Mop": "Torchon",
+                    });
+
+                    i18n.setLocale('fr-BE');
+                    expect(i18n.gettext("Mop")).to.be("Torchon");
+
+                    i18n.setLocale('fr');
+                    expect(i18n.gettext("Mop")).to.be("Serpillière");
+
+                    i18n.setLocale('fr-FR');
+                    expect(i18n.gettext("Mop")).to.be("Serpillière");
                 });
             });
 


### PR DESCRIPTION
Language can have subtags like https://www.ietf.org/rfc/bcp/bcp47.txt
The GNU gettext behavior is to search to father language if there is no translation for the actual language. So this change implements this behavior.