### PR TITLE
Fix literal percent sign (%) handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ Translate a pluralizable string
 It uses the public method `i18n.strfmt("string", var1, var2, ...)` you could
 reuse elsewhere in your project.
 
+#### Literal percent sign (%)
+
+When you need to have literal percent sign followed by a number (common in Hebrew or Turkish) you can escape it using another percent sign, for example:
+
+`gettext('My credit card has an interest rate of %%%1', 20);` -> "My credit card has an interest rate of %20"
+
+or without variables
+
+`gettext('My credit card has an interest rate of %%20');` -> "My credit card has an interest rate of %20"
+
 
 ## Required JSON format
 

--- a/lib/gettext.js
+++ b/lib/gettext.js
@@ -46,9 +46,15 @@
       var strfmt = function (fmt) {
         var args = arguments;
 
-        return fmt.replace(/%(\d+)/g, function (str, p1) {
-          return args[p1];
-        });
+        return fmt
+          // put space after double % to prevent placeholder replacement of such matches
+          .replace(/%%/g, '%% ')
+          // replace placeholders
+          .replace(/%(\d+)/g, function (str, p1) {
+            return args[p1];
+          })
+          // replace double % and space with single %
+          .replace(/%% /g, '%')
       };
 
       var expand_locale = function(locale) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -50,6 +50,12 @@
                 it('should handle repeat', function () {
                     expect(i18n.strfmt('foo %1 baz %1', 'bar', 42)).to.be('foo bar baz bar');
                 });
+                it('should handle literal percent (%) signs', function () {
+                    expect(i18n.strfmt('foo 1%% bar')).to.be('foo 1% bar');
+                    expect(i18n.strfmt('foo %1%% bar', 10)).to.be('foo 10% bar');
+                    expect(i18n.strfmt('foo %%1 bar')).to.be('foo %1 bar');
+                    expect(i18n.strfmt('foo %%%1 bar', 10)).to.be('foo %10 bar');
+                });
             });
 
             describe('expand_locale', function() {


### PR DESCRIPTION
Hi @guillaumepotier, the README states that:

> gettext.js is (...) complete and accurate GNU gettext port

however, there's an important bit missing: ability to have a literal `%` sign in the message before the number. While this is uncommon in english for example, in Turkish or Hebrew languages you put percent sign in front of a number, so if my string is:

> My credit card has an interest rate of %10

then gettext.js will transform it into 

> My credit card has an interest rate of %undefined

because it will try to look for 10th replacement (11th argument) to `strfmt` function.

The usual way to have literal `%` in the message is to use `%%` – see https://www.gnu.org/software/gettext/manual/gettext.html for reference.

----

Here is my proposed solution to this problem. I have added a test case that fails with the current code and that works correctly with updated one. All other tests are passing as well.

The solution is backwards compatible in a sense it does not require current users to always escape `%` signs in their messages, but will work correctly if they escape it. However, the solution is a breaking change for those already using `%%` sequences in their messages. The unambiguous solution would be to require users to always escape `%` with another `%` as stated in gettext manual or using proper String Format function that already does that.

I have prepared jsperf test case to see performance impacts of this change: https://jsperf.com/gettext-js-strfmt-literal-percent. It looks like the new `strfmt` function is about ~25% slower, which is acceptable in my opinion.

Let me know what you think.