### PR TITLE
separate main from module for nodejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,6 @@
   "spm": {
     "main": "lib/gettext.js"
   },
-  "main": "lib/gettext.js"
+  "main": "dist/gettext.cjs.min.js",
+  "module": "lib/gettext.js"
 }


### PR DESCRIPTION
How about using module instead of main for webpack/rollup?

At least for me, this work in raw Node, Webpack and Rollup (I use Webpack on the front and Rollup for Node on the back)

#30 