### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "gettext.js",
   "version": "0.9.0",
+  "license": "MIT",
   "scripts": {
     "test": "karma start tests/karma.config.js",
     "test-dev": "karma start tests/karma.config.dev.js",


### PR DESCRIPTION
Adding license field to the `package.json` to match the license stated in the README.