### PR TITLE
Updating README to suggest the po2json wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ or without variables
 
 ## Required JSON format
 
-You'll find in `/bin` a `po2json-gettextjs` converter, based on the excellent
-[po2json](https://github.com/mikeedwards/po2json) project that will dump your
-`.po` files into the proper json format below:
+You'll find in `/bin` a `po2json-gettextjs` converter. A `po2json` wrapper for `gettext.js`
+based on the excellent [po2json](https://github.com/mikeedwards/po2json) project that will
+dump your `.po` files into the proper json format below:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ or without variables
 
 ## Required JSON format
 
-You'll find in `/bin` a `po2json.js` converter, based on the excellent
+You'll find in `/bin` a `po2json-gettextjs` converter, based on the excellent
 [po2json](https://github.com/mikeedwards/po2json) project that will dump your
 `.po` files into the proper json format below:
 
@@ -161,8 +161,8 @@ You'll find in `/bin` a `po2json.js` converter, based on the excellent
 }
 ```
 
-Use `bin/po2json.js input.po output.json` or
-`bin/po2json.js input.po output.json -p` for pretty format.
+Use `bin/po2jsonpo2json-gettextjs input.po output.json` or
+`bin/po2jsonpo2json-gettextjs input.po output.json -p` for pretty format.
 
 
 ## Parsers


### PR DESCRIPTION
The README currently suggests using `bin/po2json.js` to convert `.po` files to `.json` files. This creates a json where all values are arrays with `null` as the first item in the array. This occurred even for singular items like so:
```
{
  "Most Popular": [null, "Les plus populaires"],
  "Add Manual Account": [null, "Ajouter un compte manuel"],
  "We can't find what you're searching for. Give these tips a try:": [
    null,
    "Nous ne pouvons pas trouver ce que vous cherchez. Essayez ces conseils:"
  ],
  "": {
    "project-id-version": "PACKAGE VERSION",
    "report-msgid-bugs-to": "",
    "pot-creation-date": "2020-05-18 19:37-0600",
    "po-revision-date": "YEAR-MO-DA HO:MI+ZONE",
    "last-translator": "FULL NAME <EMAIL@ADDRESS>",
    "language-team": "French <LL@li.org>",
    "language": "fr-ca",
    "mime-version": "1.0",
    "content-type": "text/plain; charset=UTF-8",
    "content-transfer-encoding": "8bit",
    "plural-forms": "nplurals=2; plural=(n!=1);"
  }
}
```
It seems this format does not work for gettext.js. My updates suggest using `bin/po2json-gettextjs` so the format is as follows which does work for gettext.js:
```
{
  "Most Popular": "Les plus populaires",
  "Add Manual Account": "Ajouter un compte manuel",
  "We can't find what you're searching for. Give these tips a try:": "Nous ne pouvons pas trouver ce que vous cherchez. Essayez ces conseils:",
  "": { "language": "fr-ca", "plural-forms": "nplurals=2; plural=(n!=1);" }
}
```