### PR TITLE
node compatibility fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Install the lib with the following command: `npm install gettext.js --save`
 Require it in your project:
 
 ```javascript
-var i18n = require('gettext.js');
+var i18n = require('gettext.js')();
 i18n.gettext('foo');
 ```
 

--- a/lib/gettext.js
+++ b/lib/gettext.js
@@ -1,7 +1,7 @@
 /*! gettext.js - Guillaume Potier - MIT Licensed */
 var i18n = function (options) {
  options = options || {};
- this.__version = '1.0.0';
+ this && (this.__version = '1.0.0');
 
  // default values that could be overriden in i18n() construct
  var defaults = {


### PR DESCRIPTION
Here are 2 more minor node compatiblity fixes
* i18n is a function and should be called to get the module interface object
* this is undefined when this function is called directly (it is defined when node evaluates the top-level code in a *require()*)

Normally these should not affect anything else