### PR TITLE
Normalize locale

### DIFF
--- a/lib/gettext.js
+++ b/lib/gettext.js
@@ -77,6 +77,15 @@ var i18n = function (options) {
        }
        return locales;
    };
+ 
+   var normalizeLocale = function(locale) {
+      // Convert locale to BCP 47. If the locale is in POSIX format, locale variant and encoding is discarded.
+      locale = locale.replace('_', '-');
+      var i = locale.search(/[.@]/);
+      if(i != -1)
+         locale = locale.slice(0, i);
+      return locale;
+   };
 
    var getPluralFunc = function (plural_form) {
      // Plural form string regexp
@@ -139,6 +148,8 @@ var i18n = function (options) {
 
      if ('string' !== typeof domain || 'string' !== typeof locale || !_.isObject(messages))
        throw new Error('Invalid arguments');
+    
+     locale = normalizeLocale(locale);
 
      if (plural_forms)
        _plural_forms[locale] = plural_forms;
@@ -163,7 +174,7 @@ var i18n = function (options) {
      return this.setMessages(domain || defaults.domain, headers['language'], jsonData, headers['plural-forms']);
    },
    setLocale: function (locale) {
-     _locale = locale;
+     _locale = normalizeLocale(locale);
      return this;
    },
    getLocale: function () {


### PR DESCRIPTION
Normalize locales, so the locale from [gettext files](https://www.gnu.org/software/gettext/manual/gettext.html#Locale-Names) and the [`lang` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang) become compatible.

Closes https://github.com/guillaumepotier/gettext.js/issues/54.