### PR TITLE
Update po2json dep to latest available beta version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "po2json-gettextjs": "bin/po2json"
   },
   "dependencies": {
-    "po2json": "^0.4.0"
+    "po2json": "^1.0.0-beta-3"
   },
   "devDependencies": {
     "del": "latest",


### PR DESCRIPTION
This fixes a long-standing npm audit failure. This is for a beta version but upstream has been [waiting on a stable release](https://github.com/mikeedwards/po2json/issues/101) for a while now.

As an alternate approach: what do you think about removing the `po2json` dependency completely? Instead just link to that repo in the README (similar to what  #38 is proposing). I'm fuzzy on what the value-add of the `bin/po2json` wrapper script is, and we just call out to po2json directly. That removal would make `gettext.js` a zero-dependency library with a stable API and with no now (or future!) NPM drama :stuck_out_tongue_closed_eyes: ).