### PR TITLE
don't pass the count as the first argument to strfmt

### DIFF
--- a/lib/gettext.js
+++ b/lib/gettext.js
@@ -129,7 +129,7 @@ var i18n = function (options) {
      if ('undefined' === typeof plural.plural || plural.plural > plural.nplurals || messages.length <= plural.plural)
        plural.plural = 0;
 
-     return strfmt.apply(this, [removeContext(messages[plural.plural]), n].concat(Array.prototype.slice.call(arguments, 3)));
+     return strfmt.apply(this, [removeContext(messages[plural.plural])].concat(Array.prototype.slice.call(arguments, 3)));
    };
 
  return {


### PR DESCRIPTION
This messes up the indices for strings which don't expect the number to be the first index.

e.g.

```js
i18n.dcnpgettext(
  null,
  "requirement",
  "%1 (%2 charge)",
  "%1 (%2 charges)",
  tool.count,
  tool.name,
  tool.count
)
```

`n` should be used to determine the plural form, but not also take the first argument slot.