### PR TITLE
Use GitHub Actions and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [9.x, 14.x, 16.x, 18.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - 9
-script:
-  - npm run-script test


### PR DESCRIPTION
## Changes:

- Replace Travis with GitHub Actions
- Use Dependabot to update npm and GitHub Action dependencies

## Context:

Your Travis tests don't work anymore. I think you should try out GitHub Actions. Using GitHub Actions is free on public repositories.

To get you up-to-date on your dependencies, I created a Dependabot configuration, which will update your:

- GitHub Action dependencies:
  - `actions/checkout@v3`
  - `actions/setup-node@v3`
- npm packages:
  - everything in `dependencies`
  - everything in `deDependencies`
  - Dependabot will also update your `package-lock.json` file

For now I've told Dependabot to update you `daily`, but you can get `weekly` or `monthly` updates if you want. 😉 

## Documentation

The GitHub docs you'll need are:

- [Configuring Dependabot version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates)
- [Customizing dependency updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates)
- [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions)